### PR TITLE
Fix release ui crashing when using PullRequestStatus

### DIFF
--- a/.azext/changelog-cache.json
+++ b/.azext/changelog-cache.json
@@ -1,6 +1,20 @@
 {
   "issues": [
     {
+      "id": 1343469705,
+      "number": 15,
+      "submitter": "teuciont",
+      "title": "Azure classic release \"Pull Request Status\" task: Unable to set action to Update",
+      "url": "https://github.com/joachimdalen/azdevops-pull-request-utils/issues/15"
+    },
+    {
+      "id": 1341413671,
+      "number": 13,
+      "submitter": "knoxi",
+      "title": "PullRequest Comment Task don't set proper status",
+      "url": "https://github.com/joachimdalen/azdevops-pull-request-utils/issues/13"
+    },
+    {
       "id": 1231461604,
       "number": 10,
       "submitter": "CurlyBytes",
@@ -16,6 +30,13 @@
     }
   ],
   "pullRequests": [
+    {
+      "id": 1029152486,
+      "number": 14,
+      "submitter": "joachimdalen",
+      "title": "Deprecate system comment type",
+      "url": "https://github.com/joachimdalen/azdevops-pull-request-utils/pull/14"
+    },
     {
       "id": 933969209,
       "number": 11,

--- a/.azext/changelog-cache.json
+++ b/.azext/changelog-cache.json
@@ -31,6 +31,13 @@
   ],
   "pullRequests": [
     {
+      "id": 1031714364,
+      "number": 16,
+      "submitter": "joachimdalen",
+      "title": "Fix release ui crashing when using PullRequestStatus",
+      "url": "https://github.com/joachimdalen/azdevops-pull-request-utils/pull/16"
+    },
+    {
       "id": 1029152486,
       "number": 14,
       "submitter": "joachimdalen",

--- a/.azext/changelog.json
+++ b/.azext/changelog.json
@@ -43,7 +43,8 @@
           {
             "type": "fix",
             "description": "Fix release ui crashing when setting the status to `Update`",
-            "issue": 15
+            "issue": 15,
+            "pullRequest": 16
           }
         ]
       },

--- a/.azext/changelog.json
+++ b/.azext/changelog.json
@@ -9,7 +9,8 @@
         "changes": [
           {
             "type": "maint",
-            "description": "Update dependencies"
+            "description": "Update dependencies",
+            "pullRequest": 14
           }
         ]
       },
@@ -19,17 +20,30 @@
         "changes": [
           {
             "type": "maint",
-            "description": "Update dependencies"
+            "description": "Update dependencies",
+            "pullRequest": 14
+          },
+          {
+            "type": "fix",
+            "description": "Deprecate the `type` option. System comments are causing issues and not really supported",
+            "issue": 13,
+            "pullRequest": 14
           }
         ]
       },
       {
         "name": "PullRequestStatus",
-        "version": "0.5.1",
+        "version": "0.5.2",
         "changes": [
           {
             "type": "maint",
-            "description": "Update dependencies"
+            "description": "Update dependencies",
+            "pullRequest": 14
+          },
+          {
+            "type": "fix",
+            "description": "Fix release ui crashing when setting the status to `Update`",
+            "issue": 15
           }
         ]
       },
@@ -39,7 +53,8 @@
         "changes": [
           {
             "type": "maint",
-            "description": "Update dependencies"
+            "description": "Update dependencies",
+            "pullRequest": 14
           }
         ]
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 - Fix release ui crashing when setting the status to `Update`
   - Reported in [GH#15 - Azure classic release "Pull Request Status" task: Unable to set action to Update](https://github.com/joachimdalen/azdevops-pull-request-utils/issues/15)
+  - Fixed in [PR#16 - Fix release ui crashing when using PullRequestStatus](https://github.com/joachimdalen/azdevops-pull-request-utils/pull/16)
 
 ## 🌟 Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,42 @@
 #### `PullRequestDescription@0.5.1`
 
 - Update dependencies
+  - Changed in [PR#14 - Deprecate system comment type](https://github.com/joachimdalen/azdevops-pull-request-utils/pull/14)
 
 #### `PullRequestComments@0.4.1`
 
 - Update dependencies
+  - Changed in [PR#14 - Deprecate system comment type](https://github.com/joachimdalen/azdevops-pull-request-utils/pull/14)
 
-#### `PullRequestStatus@0.5.1`
+#### `PullRequestStatus@0.5.2`
 
 - Update dependencies
+  - Changed in [PR#14 - Deprecate system comment type](https://github.com/joachimdalen/azdevops-pull-request-utils/pull/14)
 
 #### `PullRequestTags@0.4.1`
 
 - Update dependencies
+  - Changed in [PR#14 - Deprecate system comment type](https://github.com/joachimdalen/azdevops-pull-request-utils/pull/14)
+
+### 🐛 Fixes (2)
+
+#### `PullRequestComments@0.4.1`
+
+- Deprecate the `type` option. System comments are causing issues and not really supported
+  - Reported in [GH#13 - PullRequest Comment Task don't set proper status](https://github.com/joachimdalen/azdevops-pull-request-utils/issues/13)
+  - Fixed in [PR#14 - Deprecate system comment type](https://github.com/joachimdalen/azdevops-pull-request-utils/pull/14)
+
+#### `PullRequestStatus@0.5.2`
+
+- Fix release ui crashing when setting the status to `Update`
+  - Reported in [GH#15 - Azure classic release "Pull Request Status" task: Unable to set action to Update](https://github.com/joachimdalen/azdevops-pull-request-utils/issues/15)
+
+## 🌟 Contributors
+
+Thank you to the following for contributing to the latest release
+
+- [@teuciont](https://github.com/teuciont)
+- [@knoxi](https://github.com/knoxi)
 
 ---
 
@@ -49,6 +73,13 @@ Thank you to the following for contributing to the latest release
 
 ## 1.1.0 (2022-03-25)
 
+### 🐛 Fixes (1)
+
+#### `PullRequestStatus@0.5.0`
+
+- Fixed an issue where action `Delete` did not load the correct status
+  - Fixed in [PR#8 - Add option to conditionally update status](https://github.com/joachimdalen/azdevops-pull-request-utils/pull/8)
+
 ### 🚀 Features (1)
 
 #### `PullRequestStatus@0.5.0`
@@ -56,13 +87,6 @@ Thank you to the following for contributing to the latest release
 - Added new argument `whenState` to control when a status update should be applied
   - Suggested in [GH#7 - Update PullRequestStatus only if the status is fulfilled](https://github.com/joachimdalen/azdevops-pull-request-utils/issues/7)
   - Added in [PR#8 - Add option to conditionally update status](https://github.com/joachimdalen/azdevops-pull-request-utils/pull/8)
-
-### 🐛 Fixes (1)
-
-#### `PullRequestStatus@0.5.0`
-
-- Fixed an issue where action `Delete` did not load the correct status
-  - Fixed in [PR#8 - Add option to conditionally update status](https://github.com/joachimdalen/azdevops-pull-request-utils/pull/8)
 
 ## 🌟 Contributors
 
@@ -307,6 +331,14 @@ Thank you to the following for contributing to the latest release
 
 ## 0.4.2 (2021-01-27)
 
+### 🐛 Fixes (2)
+
+#### `PullRequestComments@0.2.0`
+
+- Fixed `skipIfCommentExists` not working properly. It was dumb previously and only checked the content of the comment. It is now updated to add a hidden identifier to the comment to properly identify if it exists. If you use multiple tasks, ensure `commentId` is set as a unique value for each task.
+
+- Fixed some configuration options not showing in the editor
+
 ### 🚀 Features (3)
 
 #### `PullRequestDescription@0.1.1`
@@ -318,14 +350,6 @@ Thank you to the following for contributing to the latest release
 - Added option `commentId`
 
 - Added option `action`, you can now create or update comments.
-
-### 🐛 Fixes (2)
-
-#### `PullRequestComments@0.2.0`
-
-- Fixed `skipIfCommentExists` not working properly. It was dumb previously and only checked the content of the comment. It is now updated to add a hidden identifier to the comment to properly identify if it exists. If you use multiple tasks, ensure `commentId` is set as a unique value for each task.
-
-- Fixed some configuration options not showing in the editor
 
 ---
 

--- a/tasks/pull-request-comments/task.json
+++ b/tasks/pull-request-comments/task.json
@@ -82,7 +82,7 @@
     },
     {
       "name": "type",
-      "label": "Comment Type",
+      "label": "Comment Type (Deprecated)",
       "type": "pickList",
       "helpMarkDown": "The type of comment. `Text` represents a regular user comment while `System` indicates a system message",
       "defaultValue": "Text",

--- a/tasks/pull-request-status/task.json
+++ b/tasks/pull-request-status/task.json
@@ -11,7 +11,7 @@
   "version": {
     "Major": 0,
     "Minor": 5,
-    "Patch": 1
+    "Patch": 2
   },
   "instanceNameFormat": "$(Action)",
   "inputs": [
@@ -89,7 +89,7 @@
       },
       "visibleRule": "action = Update",
       "properties": {
-        "MultiSelect": "True"
+        "MultiSelectFlatList": "True"
       }
     }
   ],


### PR DESCRIPTION
Turns out there are two types of multi select lists - this change uses the one supported in both classic and yaml editors.